### PR TITLE
Fix error when trying to edit Changelog entry from the console

### DIFF
--- a/bin/mr_bump
+++ b/bin/mr_bump
@@ -5,6 +5,7 @@
 
 # Script to tag releases and update changelogs
 require 'optparse'
+require 'tempfile'
 
 require 'mr_bump'
 require 'mr_bump/git_api'

--- a/mr_bump.gemspec
+++ b/mr_bump.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name               = 'mr_bump'
-  s.version            = '0.3.7'
+  s.version            = '0.3.8'
   s.licenses           = ['MPL-2.0']
   s.default_executable = 'mr_bump'
   s.executables        = ['mr_bump']
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
     s.required_rubygems_version = Gem::Requirement.new('>= 0')
   end
 
-  s.authors = ['Richard Fitzgerald', 'Josh Bryant']
+  s.authors = ['Richard Fitzgerald', 'Josh Bryant', 'Lukasz Ozimek']
   s.date = '2016-08-18'
   s.description = 'Bump versions'
   s.email = 'richard.fitzgerald36@gmail.com'


### PR DESCRIPTION
When trying to edit the changes proposed to Changelog from the console, we face `NameError: uninitialized constant Tempfile` for projects with no Tempfile required somewhere. It should be required by the gem itself.