### PR TITLE
Prompt for release name when cutting new release from develop

### DIFF
--- a/bin/mr_bump
+++ b/bin/mr_bump
@@ -174,8 +174,12 @@ end
 
 changes = MrBump.change_log_items_for_range(last_release, MrBump.current_branch)
             .reject(&:has_no_detail?)
-release_name = MrBump.release_name
-changes.shift if release_name
+
+if develop
+  print "Please type the name of the release here2: "
+  release_name = STDIN.gets.chomp
+end
+
 changes = changes.map(&:to_md).join("\n")
 md_changes = "# #{new_release} #{release_name}\n#{changes}\n\n"
 

--- a/lib/mr_bump.rb
+++ b/lib/mr_bump.rb
@@ -129,17 +129,6 @@ module MrBump
     end.flatten.compact
   end
 
-  def self.release_name
-    revision = MrBump.last_release
-    head = MrBump.current_branch
-    changes = change_log_items_for_range(revision, head).reject(&:has_no_detail?)
-    release_branch_name = changes.first.branch_name
-    ticket_prefix = config_file['ticket_prefix'].downcase
-    release_regex = /(#{ticket_prefix}|task|refinement|hotfix|bugfix)/
-    release_subbranch = release_branch_name.downcase[release_regex].nil?
-    release_branch_name.split("_").map(&:capitalize).join(' ') if release_subbranch
-  end
-
   def self.file_prepend(file, str)
     new_contents = ''
     File.open(file, 'r') do |fd|

--- a/mr_bump.gemspec
+++ b/mr_bump.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name               = 'mr_bump'
-  s.version            = '0.3.9'
+  s.version            = '0.3.10'
   s.licenses           = ['MPL-2.0']
   s.default_executable = 'mr_bump'
   s.executables        = ['mr_bump']

--- a/spec/mr_bump_spec.rb
+++ b/spec/mr_bump_spec.rb
@@ -534,56 +534,6 @@ describe MrBump do
     end
   end
 
-  describe '#release_name' do
-    before(:each) do
-      allow(MrBump).to receive(:merge_logs).and_return(log)
-    end
-    let(:release_name) { MrBump.release_name }
-
-    context 'when valid release name branch merged' do
-      let(:log) do
-        [
-          'Merge pull request #41 from mr_bump/atomic_anteater',
-          'Merge pull request #4 from mr_bump/hotfix/DEV-1261',
-          'Comment',
-          'Merge pull request #1376 from mr_bump/release/10.19.0',
-          'Comment',
-          'Over several',
-          'Lines',
-          'Merge pull request #233 from mr_bump/bugfix/master',
-          'asdasd',
-          'Merge pull request #1336 from mr_bump/MDV-1261',
-          'wqefqfqefqwefqef'
-        ]
-      end
-
-      it 'converts raw git log ouput to proper release name' do
-        expect(release_name).to eq('Atomic Anteater')
-      end
-    end
-
-    context 'when NO valid release name branch merged' do
-      let(:log) do
-        [
-          'Merge pull request #4 from mr_bump/hotfix/PBW-1261',
-          'Comment',
-          'Merge pull request #1376 from mr_bump/release/10.19.0',
-          'Comment',
-          'Over several',
-          'Lines',
-          'Merge pull request #233 from mr_bump/bugfix/master',
-          'asdasd',
-          'Merge pull request #1336 from mr_bump/MDV-1261',
-          'wqefqfqefqwefqef'
-        ]
-      end
-
-      it 'returns nil as release name' do
-        expect(release_name).to eq(nil)
-      end
-    end
-  end
-
   describe '#last_release' do
     before do
       allow(MrBump).to receive(:current_uat).and_return(MrBump::Version.new('0.1.3'))


### PR DESCRIPTION
Reading the release name from the branch name is quite tricky and may cause problems. The fact is that typing in the release name during cutting a new release is a much better option, it does the job perfectly fine with actually no additional effort